### PR TITLE
Removing auto exit on nonzero status

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-set -e
-
 unset GIT_DIR
 
 for BUILDPACK in $(cat $1/.buildpacks); do


### PR DESCRIPTION
This is causing the buildpack to swallow any error messages because it exits before it has time to echo.