### PR TITLE
Removing backslash

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -50,7 +50,7 @@ for BUILDPACK in $(cat $1/.buildpacks); do
         $dir/bin/release $1 > $1/last_pack_release.out
       fi
     else
-      echo "Couldn't detect any framework for this buildpack. Exiting."
+      echo "Could not detect any framework for this buildpack. Exiting."
       exit 1
     fi
   fi


### PR DESCRIPTION
Just a logging change, no logic change.

Herokuish uses `read -r line` and the -r flag is described as `do not allow backslashes to escape any characters` therefore using the word `couldn't` is not being read because of the apostrophe.